### PR TITLE
introducing layoutSubviews 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 RangeSlider.xcodeproj/xcuserdata
+.DS_Store
+DerivedData/
+RangeSlider.xcodeproj/project.xcworkspace/xcuserdata/

--- a/RangeSlider/RangeSlider.m
+++ b/RangeSlider/RangeSlider.m
@@ -22,7 +22,6 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        // Set the initial state
         _minThumbOn = false;
         _maxThumbOn = false;
         _padding = 20;
@@ -38,21 +37,31 @@
         _minThumb = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"handle.png"] highlightedImage:[UIImage imageNamed:@"handle-hover.png"]] autorelease];
         _minThumb.frame = CGRectMake(0,0, self.frame.size.height,self.frame.size.height);
         _minThumb.contentMode = UIViewContentModeCenter;
-		_minThumb.center = CGPointMake([self xForValue:selectedMinimumValue], self.center.y);
-		[self addSubview:_minThumb];
+        [self addSubview:_minThumb];
         
         _maxThumb = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"handle.png"] highlightedImage:[UIImage imageNamed:@"handle-hover.png"]] autorelease];
         _maxThumb.frame = CGRectMake(0,0, self.frame.size.height,self.frame.size.height);
         _maxThumb.contentMode = UIViewContentModeCenter;
-		_maxThumb.center = CGPointMake([self xForValue:selectedMaximumValue], self.center.y);
-		[self addSubview:_maxThumb];
-        NSLog(@"Tapable size %f", _minThumb.bounds.size.width); 
-        [self updateTrackHighlight];
-
+        [self addSubview:_maxThumb];
     }
+    
     return self;
 }
 
+
+-(void)layoutSubviews
+{
+    // Set the initial state
+    _minThumb.center = CGPointMake([self xForValue:selectedMinimumValue], self.center.y);
+    
+    _maxThumb.center = CGPointMake([self xForValue:selectedMaximumValue], self.center.y);
+    
+    
+    NSLog(@"Tapable size %f", _minThumb.bounds.size.width); 
+    [self updateTrackHighlight];
+    
+    
+}
 
 -(float)xForValue:(float)value{
     return (self.frame.size.width-(_padding*2))*((value - minimumValue) / (maximumValue - minimumValue))+_padding;
@@ -78,7 +87,7 @@
         selectedMaximumValue = [self valueForX:_maxThumb.center.x];
     }
     [self updateTrackHighlight];
-    [self setNeedsDisplay];
+    [self setNeedsLayout];
     
     [self sendActionsForControlEvents:UIControlEventValueChanged];
     return YES;
@@ -89,12 +98,12 @@
     
     if(CGRectContainsPoint(_minThumb.frame, touchPoint)){
         _minThumbOn = true;
-         distanceFromCenter = touchPoint.x - _minThumb.center.x;
+        distanceFromCenter = touchPoint.x - _minThumb.center.x;
     }
     else if(CGRectContainsPoint(_maxThumb.frame, touchPoint)){
         _maxThumbOn = true;
-         distanceFromCenter = touchPoint.x - _maxThumb.center.x;
-
+        distanceFromCenter = touchPoint.x - _maxThumb.center.x;
+        
     }
     return YES;
 }
@@ -114,12 +123,12 @@
 }
 
 /*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect
-{
-    // Drawing code
-}
-*/
+ // Only override drawRect: if you perform custom drawing.
+ // An empty implementation adversely affects performance during animation.
+ - (void)drawRect:(CGRect)rect
+ {
+ // Drawing code
+ }
+ */
 
 @end

--- a/RangeSlider/RootViewController.m
+++ b/RangeSlider/RootViewController.m
@@ -68,7 +68,7 @@
 
 
         // Configure the cell.
-        RangeSlider *slider=  [RangeSlider alloc];
+        RangeSlider *slider=  [[RangeSlider alloc] initWithFrame:cell.bounds];
         slider.minimumValue = 1;
         slider.selectedMinimumValue = 2;
         slider.maximumValue = 10;
@@ -76,7 +76,6 @@
         slider.minimumRange = 2;
         [slider addTarget:self action:@selector(updateRangeLabel:) forControlEvents:UIControlEventValueChanged];
 
-        [slider initWithFrame:cell.bounds];
         
         [cell addSubview:slider];
     


### PR DESCRIPTION
Hey, 

I restructured RangeSlider and added `layoutSubviews` to be able to call `RangeSlider *slider=  [[RangeSlider alloc] initWithFrame:cell.bounds];` instead of allocating, setting the properties and then initializing.
